### PR TITLE
feat: add ability to specify `nginx_proxy.conf` file

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v1
       - run: npm install --no-save
       - run:
           npm run lint:commit -- --from="origin/${{ github.base_ref }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v1
 
       - uses: actions/setup-node@v1
         with:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,7 +14,7 @@ jobs:
         node: [12.x]
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v1
 
       - uses: actions/setup-node@v1
         with:

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "commander": "^2.20.0",
     "dockerode": "^2.5.8",
     "execa": "^1.0.0",
+    "fs": "0.0.1-security",
     "listr": "^0.14.3",
     "lodash": "^4.17.11"
   },

--- a/src/containers/proxyConfig.js
+++ b/src/containers/proxyConfig.js
@@ -1,5 +1,6 @@
 import { homedir } from 'os';
 import { resolve } from 'path';
+import fs from 'fs';
 
 export default {
   Image: 'codekitchen/dinghy-http-proxy:latest',
@@ -14,6 +15,14 @@ export default {
     Binds: [
       '/var/run/docker.sock:/tmp/docker.sock:ro',
       `${resolve(homedir(), '.dotdocker/certs')}:/etc/nginx/certs:ro`,
+      ...(fs.existsSync(`${resolve(homedir(), '.dotdocker/nginx_proxy.conf')}`)
+        ? [
+            `${resolve(
+              homedir(),
+              '.dotdocker/nginx_proxy.conf',
+            )}:/etc/nginx/conf.d/nginx_proxy.conf:ro`,
+          ]
+        : []),
     ],
     PortBindings: {
       '19322/udp': [


### PR DESCRIPTION
If there's an `nginx_proxy.conf` file in the user's `$HOME/.docker/` directory.

This will allow for custom nginx configs like setting headers or mutual TLS using x.509 certificates in local setups.